### PR TITLE
Se exporta clase de ToastLauncher

### DIFF
--- a/lib/components/Toaster/helper.ts
+++ b/lib/components/Toaster/helper.ts
@@ -71,8 +71,6 @@ export class ToastLauncher {
   }
 }
 
-export const toastLauncher = new ToastLauncher()
-
 export class Timer {
   private timerId: number
   private start: Date

--- a/lib/components/Toaster/index.tsx
+++ b/lib/components/Toaster/index.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import ReactDOM from 'react-dom'
 
 import Toast, { ToastType } from './Toast'
-import { toastLauncher, Timer } from './helper'
+import { ToastLauncher, Timer } from './helper'
 import useStyles from './styles'
 
 const timings = {
@@ -12,9 +12,10 @@ const timings = {
 
 interface ToasterProps {
   container?: HTMLElement
+  toastLauncher: ToastLauncher
 }
 
-const Toaster = ({ container }: ToasterProps) => {
+const Toaster = ({ container, toastLauncher }: ToasterProps) => {
   const classes = useStyles()
   const [toast, setToast] = useState<ToastType | null>()
   const [toastId, setToastId] = useState()
@@ -35,7 +36,7 @@ const Toaster = ({ container }: ToasterProps) => {
         setToast(null)
       }, 300)
     },
-    [resetTimer, timer]
+    [resetTimer, timer, toastLauncher]
   )
 
   const addTimer = useCallback(
@@ -73,7 +74,7 @@ const Toaster = ({ container }: ToasterProps) => {
     return () => {
       toastLauncher.removeListener(listener)
     }
-  }, [onAdd, onClose])
+  }, [onAdd, onClose, toastLauncher])
 
   useEffect(() => {
     if (toast && !toast.closing) addTimer(toast)


### PR DESCRIPTION
# Description
Se modifica Toaster para recibir toastLauncher como prop en lugar de recibir una instancia directamente de la librería.
Para usar los toasts es necesario generar una instancia del toast launcher en la aplicación cliente y pasarlo como prop a `<Toaster />`. Para lanzar toast será necesario llamar a dicha instancia, por lo que hay qué exportarla en el archivo en el que se declare.

La razón de este cambio es para desacoplar la funcionalidad de Toaster y el ToastLauncher (aún falta separar algunas funcionalidades), puedes implementar tu propio componente de Toaster que cumpla con la funcionalidad de ToastLauncher o viceversa.