### PR TITLE
fix: Change logical expresion for close Button (fullSize prop)

### DIFF
--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -147,9 +147,9 @@ const Modal = (props: ModalProps) => {
               <Flexbox flex={imgLeft?.img ? '1' : null}>
                 {fullSize && isMobile ? (
                   <div className={classes.top}>
-                    <div className={classes.top}>
+                    <Flexbox className={classes.top}>
                       {!imgTop?.img && onClose && closeButton}
-                    </div>
+                    </Flexbox>
                     {title && (
                       <Text heading className={classes.title}>
                         {title}

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -147,9 +147,9 @@ const Modal = (props: ModalProps) => {
               <Flexbox flex={imgLeft?.img ? '1' : null}>
                 {fullSize && isMobile ? (
                   <div className={classes.top}>
-                    <Flexbox alignItems="end" className={classes.top}>
-                      {(!imgTop?.img && onClose) ?? closeButton}
-                    </Flexbox>
+                    <div className={classes.top}>
+                      {!imgTop?.img && onClose && closeButton}
+                    </div>
                     {title && (
                       <Text heading className={classes.title}>
                         {title}

--- a/lib/components/Modal/styles.ts
+++ b/lib/components/Modal/styles.ts
@@ -93,7 +93,8 @@ const styles = {
   closeIcon: {
     height: spacing.medium,
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    justifyContent: 'end'
   },
   content: {
     marginLeft: -spacing.small,

--- a/lib/components/Modal/styles.ts
+++ b/lib/components/Modal/styles.ts
@@ -93,8 +93,7 @@ const styles = {
   closeIcon: {
     height: spacing.medium,
     display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'end'
+    alignItems: 'center'
   },
   content: {
     marginLeft: -spacing.small,


### PR DESCRIPTION
Fix of error in Modal component when using the prop `fullSize`

![image](https://user-images.githubusercontent.com/91487609/156639280-84c603b4-8b9f-46d1-866d-4aef617b02bd.png)