### PR TITLE
fix: Fix modal condition to render images

### DIFF
--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -139,7 +139,7 @@ const Modal = (props: ModalProps) => {
                     { [classes.imgTop]: !imgLeft.img }
                   )}
                 >
-                  {imgTop.img && onClose && (
+                  {imgTop?.img && onClose && (
                     <div className={classes.closePosition}>{closeButton}</div>
                   )}
                 </div>


### PR DESCRIPTION
Solves an issue when imgTop prop was not passed while using imgLeft, the same issue happened in the inverse case 