### PR TITLE
Width fix

### DIFF
--- a/lib/components/Avatar/AvatarContent/index.test.tsx
+++ b/lib/components/Avatar/AvatarContent/index.test.tsx
@@ -21,7 +21,6 @@ describe('AvatarContent', () => {
     const photoUrl = 'https://example.com/photo.png'
     const { container } = render(<AvatarContent photo={photoUrl} />)
     const avatarContent = container.firstChild as HTMLElement
-    console.log(avatarContent.className)
     expect(avatarContent).toBeInTheDocument()
     const avatarPhoto = avatarContent.firstChild as HTMLElement
     expect(avatarPhoto).toHaveStyle(

--- a/lib/components/Footer/index.tsx
+++ b/lib/components/Footer/index.tsx
@@ -5,8 +5,6 @@ import Grid from '@/components/Grid'
 import Flexbox from '@/components/Flexbox'
 import Text from '@/components/Text'
 import Button from '@/components/Button'
-import grid from '@/tokens/grid'
-import useWindowSize from '@/hooks/useWindowSize'
 
 import List, { ListItem } from './List'
 import useStyles from './styles'
@@ -44,6 +42,10 @@ interface FooterProps {
   copyText?: string | ReactElement
   aux?: Aux
   listClassName?: string
+  /** The recommendation is to set the breakpoint at `grid.sm` */
+  isMobile?: boolean
+  /** The recommendation is to set the breakpoint at `grid.xl` */
+  isFluid?: boolean
 }
 
 const Footer = ({
@@ -51,10 +53,11 @@ const Footer = ({
   bottomLinks,
   copyText,
   aux,
-  listClassName
+  listClassName,
+  isMobile,
+  isFluid
 }: FooterProps) => {
   const classes = useStyles()
-  const { width } = useWindowSize()
   const {
     text,
     iconLeft,
@@ -63,7 +66,6 @@ const Footer = ({
     iconRight,
     className: auxClassName
   } = aux
-  const isMobile = width < grid.sm
 
   return (
     <div
@@ -71,7 +73,7 @@ const Footer = ({
         columns.length > 0 ? classes.footer : classes.footerWithoutColumns
       }
     >
-      <Grid fluid={width < grid.xl}>
+      <Grid fluid={isFluid}>
         <Grid.Row>
           <Flexbox
             display="flex"

--- a/lib/components/Media/index.tsx
+++ b/lib/components/Media/index.tsx
@@ -1,0 +1,18 @@
+import { createMedia } from '@artsy/fresnel'
+import grid from '@/tokens/grid'
+
+const { xxs, xs, sm, md, lg, xl } = grid
+
+const { MediaContextProvider, Media, createMediaStyle } = createMedia({
+  breakpoints: {
+    xxs,
+    xs,
+    sm,
+    md,
+    lg,
+    xl
+  }
+})
+
+const mediaStyle = createMediaStyle()
+export { MediaContextProvider, Media, mediaStyle }

--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -14,9 +14,7 @@ import Text from '@/components/Text'
 import Flexbox from '@/components/Flexbox'
 import Button from '@/components/Button'
 import colors from '@/tokens/colors'
-import grid from '@/tokens/grid'
 import iconSizes from '@/tokens/iconSizes'
-import useWindowSize from '@/hooks/useWindowSize'
 import useEventListener from '@/hooks/useEventListener'
 
 import styles from './styles'
@@ -63,6 +61,8 @@ export interface ModalProps {
   imgLeft?: ImageLeft
   onTransitionEnd?: TransitionEventHandler<HTMLDivElement>
   fullSize?: boolean
+  /** The recommendation is to set the breakpoint at `grid.xs` */
+  isMobile?: boolean
 }
 
 const Modal = (props: ModalProps) => {
@@ -78,11 +78,10 @@ const Modal = (props: ModalProps) => {
     imgTop,
     imgLeft,
     onTransitionEnd,
-    fullSize
+    fullSize,
+    isMobile
   } = props
-  const { width } = useWindowSize()
   useLockBodyScroll()
-  const isMobile = useMemo(() => width < grid.xs, [width])
 
   const onKeyDown = useCallback(
     ({ code }: KeyboardEvent) => {

--- a/lib/components/NavTab/index.tsx
+++ b/lib/components/NavTab/index.tsx
@@ -18,7 +18,6 @@ import colors from '@/tokens/colors'
 import spacing from '@/tokens/spacing'
 import grid from '@/tokens/grid'
 import iconSizes from '@/tokens/iconSizes'
-import useWindowSize from '@/hooks/useWindowSize'
 
 import useStyles from './styles'
 
@@ -45,7 +44,7 @@ interface NavElement {
 
 export interface NavPosition extends Array<NavElement> {}
 
-interface NavTabProps {
+export interface NavTabProps {
   left?: NavPosition
   right?: NavPosition
   center?: NavPosition
@@ -57,6 +56,8 @@ interface NavTabProps {
   bottom?: boolean
   zIndex?: number
   className?: string
+  /** The recommendation is to set the breakpoint at `grid.xl` */
+  isFluid?: boolean
 }
 
 const NavTab = ({
@@ -70,12 +71,12 @@ const NavTab = ({
   bottom,
   className,
   zIndex,
-  hideOnScroll
+  hideOnScroll,
+  isFluid
 }: NavTabProps) => {
   const classes = useStyles()
   const [show, setShow] = useState(true)
   const [currentScroll, setCurrentScroll] = useState(0)
-  const { width } = useWindowSize()
 
   const determineVisibility = useCallback(() => {
     setShow(
@@ -186,7 +187,6 @@ const NavTab = ({
     ]
   )
 
-  const isFluid = useMemo(() => width < grid.xl, [width])
   return (
     <div
       className={classnames(

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -10,6 +10,7 @@ import Footer from './Footer'
 import Grid from './Grid'
 import Icon from './Icon'
 import Logo from './Logo'
+import { MediaContextProvider, Media, mediaStyle } from './Media'
 import Modal from './Modal'
 import NavAside from './NavAside'
 import NavIcon from './NavIcon'
@@ -44,6 +45,9 @@ export {
   Grid,
   Icon,
   Logo,
+  Media,
+  MediaContextProvider,
+  mediaStyle,
   Modal,
   NavAside,
   NavIcon,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "deploy": "node scripts/deploy.js"
   },
   "dependencies": {
+    "@artsy/fresnel": "^6.1.0",
     "@babel/runtime": "^7.14.8",
     "classnames": "^2.3.1",
     "hex-rgba": "^1.0.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import type { AppProps } from 'next/app'
 
 import AtomicProvider from '@/components/Provider'
+import { MediaContextProvider } from '@/components/Media'
 import useIsClient from '@/hooks/useIsClient'
 
 function MyApp({ Component, pageProps }: AppProps) {
@@ -18,13 +19,15 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
-      <AtomicProvider
-        data={{
-          iconsUrl: 'https://cdn-icons.occ.com.mx/atomic-icons-1.0.0.svg'
-        }}
-      >
-        <Component key={isClient} {...pageProps} />
-      </AtomicProvider>
+      <MediaContextProvider>
+        <AtomicProvider
+          data={{
+            iconsUrl: 'https://cdn-icons.occ.com.mx/atomic-icons-1.0.0.svg'
+          }}
+        >
+          <Component key={isClient} {...pageProps} />
+        </AtomicProvider>
+      </MediaContextProvider>
     </>
   )
 }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -6,6 +6,7 @@ import Document, {
   DocumentContext
 } from 'next/document'
 import { SheetsRegistry, JssProvider } from 'react-jss'
+import { mediaStyle } from '@/components/Media'
 
 class MyDocument extends Document {
   static async getInitialProps(ctx: DocumentContext) {
@@ -66,6 +67,7 @@ class MyDocument extends Document {
             rel="stylesheet"
             href="https://fonts.googleapis.com/css2?family=Fira+Code&family=Pacifico&display=swap"
           />
+          <style dangerouslySetInnerHTML={{ __html: mediaStyle }} />
         </Head>
 
         <body>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react'
 import Link from 'next/link'
 
-import NavTab from '@/components/NavTab'
+import NavTab, { NavTabProps } from '@/components/NavTab'
 import NavAside from '@/components/NavAside'
 import Portal from '@/components/Portal'
 import Menu from '@/src/components/Menu'
 import Search from '@/src/components/Search'
 import { Doc } from '@/src/components/Layout'
+import { Media } from '@/components/Media'
 
 import useStyles from './styles'
 
@@ -18,44 +19,49 @@ export default function Header({ docs }: HeaderProps) {
   const classes = useStyles()
   const [showAside, setShowAside] = useState(false)
 
+  const navTabContent = {
+    left: [
+      {
+        key: 0,
+        type: 'icon',
+        iconName: 'menu',
+        onClick: () => setShowAside(true)
+      },
+      {
+        key: 1,
+        type: 'custom',
+        custom: (
+          <Link href="/">
+            <a className={classes.title}>Atomic</a>
+          </Link>
+        )
+      }
+    ],
+    right: [
+      {
+        key: 0,
+        type: 'link',
+        link: 'https://github.com/occmundial/atomic',
+        text: 'View on Github'
+      }
+    ],
+    center: [
+      {
+        key: 0,
+        type: 'custom',
+        custom: <Search docs={docs} />
+      }
+    ]
+  } as NavTabProps
+
   return (
     <>
-      <NavTab
-        fixed
-        hideOnScroll
-        left={[
-          {
-            key: 0,
-            type: 'icon',
-            iconName: 'menu',
-            onClick: () => setShowAside(true)
-          },
-          {
-            key: 1,
-            type: 'custom',
-            custom: (
-              <Link href="/">
-                <a className={classes.title}>Atomic</a>
-              </Link>
-            )
-          }
-        ]}
-        right={[
-          {
-            key: 0,
-            type: 'link',
-            link: 'https://github.com/occmundial/atomic',
-            text: 'View on Github'
-          }
-        ]}
-        center={[
-          {
-            key: 0,
-            type: 'custom',
-            custom: <Search docs={docs} />
-          }
-        ]}
-      />
+      <Media lessThan="xs">
+        <NavTab fixed hideOnScroll {...navTabContent} isFluid />
+      </Media>
+      <Media greaterThanOrEqual="xs">
+        <NavTab fixed hideOnScroll {...navTabContent} isFluid={false} />
+      </Media>
       <Portal show={showAside}>
         <NavAside
           onClose={() => setShowAside(false)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@artsy/fresnel@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@artsy/fresnel/-/fresnel-6.1.0.tgz#fac8aeb6a01cbd7791351dce523f5ab5e2fc8679"
+  integrity sha512-PexfFmf3Un3C752SFpryYROgahfdSsHhNETSZlJcO0W3MJ14hyw/MbLQl3DnNdQGIJZE6y1MbnH7ntEt8PWB0Q==
+
 "@babel/cli@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.14.5.tgz#9551b194f02360729de6060785bbdcce52c69f0a"


### PR DESCRIPTION
# Description
Remove the conditional rendering logic from the library, and pass it to the client.
The client side can decide if it wants to show a mobile version of the components using the `useWindowSize` hook for components that are only rendered on the client side dynamically and are able to have such dynamic behavior, or using the new `Media` component (using `@artsy/fresnel`) to server mobile and desktop version for SSR.