### PR TITLE
feat: Update footer to support new logo

### DIFF
--- a/lib/components/Footer/index.tsx
+++ b/lib/components/Footer/index.tsx
@@ -43,6 +43,7 @@ interface FooterProps {
   bottomLinks?: BottomLink[]
   copyText?: string | ReactElement
   aux?: Aux
+  bottomItem?: ReactElement
   listClassName?: string
 }
 
@@ -51,6 +52,7 @@ const Footer = ({
   bottomLinks,
   copyText,
   aux,
+  bottomItem,
   listClassName
 }: FooterProps) => {
   const classes = useStyles()
@@ -98,11 +100,27 @@ const Footer = ({
           <div className={classes.footerBottom}>
             <Flexbox
               display="flex"
-              alignItems="start"
+              alignItems={isMobile ? 'start' : 'end'}
               className={classes.bottomWrap}
               direction={isMobile ? 'col' : 'row'}
             >
               <Flexbox flex="1">
+                {aux && (
+                  <Button
+                    href={href}
+                    target={target}
+                    iconLeft={iconLeft}
+                    iconRight={iconRight}
+                    size="md"
+                    theme="ghostPink"
+                    className={classnames(
+                      { [classes.buttonMobile]: isMobile },
+                      auxClassName
+                    )}
+                  >
+                    {text}
+                  </Button>
+                )}
                 <Text small mid bottomTiny tag="div">
                   {bottomLinks.map(item => (
                     <div
@@ -129,22 +147,7 @@ const Footer = ({
                 </Text>
                 {copyText && <Text small>{copyText}</Text>}
               </Flexbox>
-              {aux && (
-                <Button
-                  href={href}
-                  target={target}
-                  iconLeft={iconLeft}
-                  iconRight={iconRight}
-                  size="md"
-                  theme="ghostPink"
-                  className={classnames(
-                    { [classes.buttonMobile]: isMobile },
-                    auxClassName
-                  )}
-                >
-                  {text}
-                </Button>
-              )}
+              {bottomItem}
             </Flexbox>
           </div>
         </Grid.Row>


### PR DESCRIPTION
- Move help aux to the top of the items
- Move logo or component in the former place of aux item

NOTA: solo se pasa el children, el logo se incluirá en los clientes para que sea agnóstico de que va en la posición de abajo

![image](https://user-images.githubusercontent.com/56703361/205739189-e28278e4-64f1-4294-b26e-ffa0692f4227.png)
![image](https://user-images.githubusercontent.com/56703361/205739260-46909ab5-c4e4-42a4-878a-6159a08ec514.png)
