### PR TITLE
fix: Autocomplete props adjust

### DIFF
--- a/lib/components/Autocomplete/index.tsx
+++ b/lib/components/Autocomplete/index.tsx
@@ -16,8 +16,10 @@ import usePrevious from '@/hooks/usePrevious'
 
 import useStyles from './styles'
 
+type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>
+
 export interface AutocompleteProps {
-  textfieldProps: Pick<
+  textfieldProps: Optional<
     TextFieldProps,
     | 'id'
     | 'type'
@@ -34,9 +36,9 @@ export interface AutocompleteProps {
     | 'lockHeight'
     | 'testId'
   >
-  droplistProps: Pick<
+  droplistProps: Optional<
     DroplistProps,
-    'items' | 'groups' | 'className' | 'filter' | 'term' | 'testId'
+    'groups' | 'className' | 'filter' | 'term' | 'testId'
   >
   onChange?: (value: string) => void
   onKeyUp?: (code: string) => void


### PR DESCRIPTION
- Change type for subcomponents props of autocomplete props, so its possible to declare optional parameters, or convert them to optional for these props, instead of forcing client to implement these properties with random values.

This helps to avoid this kind of issues on the client, where we want to pass a prop of textfield that is not included in the mandatory list of props, this helps to simplify the props that we dont need on that specific `autocomplete`
Error
![image](https://user-images.githubusercontent.com/56703361/213022820-e5ff78ca-0716-46b7-844b-0aa93bee7797.png)


Example, the params are now optional instead of forcing client to implement them
![image](https://user-images.githubusercontent.com/56703361/213022253-b46405e8-7c2e-4e48-9f49-e3578efaf352.png)
Example, the vaidation will show an error in case a mandatory property is not set
![image](https://user-images.githubusercontent.com/56703361/213022344-c49bf538-9860-4af6-b4fd-a403b66f4dcf.png)

Applies for `droplistProps` and `textfieldProps`
![image](https://user-images.githubusercontent.com/56703361/213022410-a153635a-1ecd-4099-924a-143fec21978d.png)
