### PR TITLE
fix: Fix Pill error color

### DIFF
--- a/lib/components/Pill/styles.ts
+++ b/lib/components/Pill/styles.ts
@@ -30,15 +30,10 @@ export default createUseStyles({
     display: 'flex',
     alignItems: 'center'
   },
-  assistiveText: {
-    color: colors.inkLighter
-  },
-  errorAssistiveText: {
-    color: colors.errorText
-  },
   errorIcon: {
     marginTop: -2,
-    marginRight: spacing.xTiny
+    marginRight: spacing.xTiny,
+    color: colors.errorText
   },
   stackGroup: {
     display: 'flex',


### PR DESCRIPTION
- Fix icon color
- Remove unused classes that belonged to `label` in `occ-atomic`, here in `atomic` the usage of `Text` handles the color with props `error` and `low`, hence, we can get rid of these classes

Fixed Pill
![image](https://user-images.githubusercontent.com/56703361/217601089-5e0f8599-be45-47a5-a031-e19715d63f6c.png)

How the component looks in Prod
![PILL PROD PROOF](https://user-images.githubusercontent.com/56703361/217601250-d77ed195-2b1e-405f-8d68-00b7d50a4dab.png)

