### PR TITLE
fix: Modal prop fix

### DIFF
--- a/lib/components/Modal/index.tsx
+++ b/lib/components/Modal/index.tsx
@@ -37,7 +37,7 @@ interface ModalImage {
   color?: string
   alt?: string
   size?: 'contain' | 'cover' | string
-  height: number
+  height?: number
 }
 
 interface ImageTop extends ModalImage {


### PR DESCRIPTION
- Put height in ModalImage as optional, since styles has fallback for that value if not passed, also, left image is not dependant on that value