### PR TITLE
feat: Add iconsPath property to Provider

### DIFF
--- a/lib/components/Icon/index.tsx
+++ b/lib/components/Icon/index.tsx
@@ -60,7 +60,9 @@ const Icon = ({
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
     >
-      <use xlinkHref={`#${atomic.iconsPrefix}__${iconName}`} />
+      <use
+        xlinkHref={`${atomic.iconsPath}#${atomic.iconsPrefix}__${iconName}`}
+      />
     </svg>
   )
 }

--- a/lib/components/Provider/index.tsx
+++ b/lib/components/Provider/index.tsx
@@ -13,12 +13,16 @@ import usePrevious from '@/hooks/usePrevious'
 const AtomicContext = createContext<Partial<AtomicData>>({})
 
 export interface AtomicData {
+  /** URL to fetch an svg sprite and insert it in the DOM as inline (does not work with `iconsPath`) */
   iconsUrl: string
+  /** Path to access a local svg sprite (does not work with `iconsUrl`) */
+  iconsPath: string
+  /** A prefix for the icon name in the svg sprite */
   iconsPrefix: string
 }
 
 interface AtomicProviderProps {
-  data: Partial<AtomicData>
+  data?: Partial<AtomicData>
   children: ReactNode
 }
 
@@ -28,6 +32,7 @@ const useIsomorphicLayoutEffect =
 const AtomicProvider = ({ data, children }: AtomicProviderProps) => {
   const [value, setValue] = useState<Partial<AtomicData>>({
     iconsUrl: '',
+    iconsPath: '',
     iconsPrefix: 'atomic',
     ...data
   })


### PR DESCRIPTION
# Description
Add a new property to the provider to set an `iconsPath` to access the svg sprite icons.
This approach is different to `iconsUrl` because it doesn't need to fetch the svg file and insert it in the DOM as an inline svg. `iconsUrl` does this because the icons may live in a CDN, which is a different url than the website and this is not an allowed use of the `use` property in svg (https://adamjberkowitz.com/blog/post/using-svgs-from-a-cdn).
So with this method, instead of getting the icons from another domain on demand and insert it as inline to be able to access to the icons of the sprite, the icons will be accesible without making a request before the icons are rendered and you only need to specify the path were those icons live.

To make this work in your project you will need to download the icons to your project manually and expose them in a public directory.