### PR TITLE
docs: Add component docs

### DIFF
--- a/src/components/MDXComponents.ts
+++ b/src/components/MDXComponents.ts
@@ -11,13 +11,20 @@ import Td from './Table/Td'
 import Hr from './Hr'
 import Button from '@/components/Button'
 import Card from '@/components/Card'
+import Alert from '@/components/Alert'
+import Tag from '@/components/Tag'
 import Flexbox from '@/components/Flexbox'
+import Icon from '@/components/Icon'
 import Text from '@/components/Text'
 import Anchor from './Anchor'
 
 const mdxComponents = {
   // Library components
   Button,
+  Text,
+  Alert,
+  Tag,
+  Icon,
   Card,
   Flexbox,
   // Docs components

--- a/src/docs/Alert.mdx
+++ b/src/docs/Alert.mdx
@@ -2,9 +2,198 @@
 title: Alert
 section: components
 ---
+
 import Demo from '@/utils/components/Demo'
 import Alert from '@/components/Alert'
 
 # Alert
+
 ---
-Alert docs.
+
+Alert component to display messages within a container.
+
+- [Props](#Props)
+  - [Themes](#Themes)
+  - [Icon](#Icon)
+  - [Bold](#Bold)
+  - [Action](#Action)
+  - [Others](#Others)
+
+## Props
+
+| Name             | Type         | Default value | Description                                                                                                                       |
+| ---------------- | ------------ | ------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `children`       | **string**   | -             | The Text to be rendered inside the Alert container. Some parts can be displayed as bold text if surrounded by \* symbol.          |
+| `theme`          | **string**   | `info`        | Theme of Alert component. Available options are `info`, `warning`, `success`, `error`, `promote`.                                 |
+| `icon`           | **boolean**  | `false`       | Shows an icon assigned for each theme but `promote`.                                                                              |
+| `cta`            | **object**   | -             | An action appended after text. Object has the next properties: `text(string)`, `href(string)`, `target(string)`, `onClick(func)`. |
+| `center`         | **boolean**  | -             | Centers Alert content.                                                                                                            |
+| `noBorderRadius` | **boolean**  | -             | Cancels the default border radius of Alert.                                                                                       |
+| `onClose`        | **function** | -             | Function to call onClick of the X icon.                                                                                           |
+| `spacedClose`    | **boolean**  | -             | Extra padding on the right of the X icon.                                                                                         |
+| `id`             | **string**   | -             | Alert component id.                                                                                                               |
+| `className`      | **string**   | -             | Alert component className.                                                                                                        |
+| `style`          | **object**   | -             | Object with direct style properties.                                                                                              |
+
+### Themes
+
+<Demo title="Alert themes" background={colors.bgGrey}>
+  <Alert theme="info">Alert with info theme</Alert>
+  <Alert theme="warning">Alert with warning theme</Alert>
+  <Alert theme="success">Alert with success theme</Alert>
+  <Alert theme="error">Alert with error theme</Alert>
+  <Alert theme="promote">Alert with promote theme</Alert>
+</Demo>
+
+```jsx
+// How to use themes
+function Component() {
+  return (
+    <>
+      <Alert theme="info">Alert with info theme</Alert>
+      <Alert theme="warning">Alert with warning theme</Alert>
+      <Alert theme="success">Alert with success theme</Alert>
+      <Alert theme="error">Alert with error theme</Alert>
+      <Alert theme="promote">Alert with promote theme</Alert>
+    </>
+  )
+}
+```
+
+### Icon
+
+Each theme has an associated icon.
+
+<Demo title="Alert with icons" background={colors.bgGrey}>
+  <Alert icon theme="info">
+    Alert with icon
+  </Alert>
+  <Alert icon theme="warning">
+    Alert with icon
+  </Alert>
+  <Alert icon theme="success">
+    Alert with icon
+  </Alert>
+  <Alert icon theme="error">
+    Alert with icon
+  </Alert>
+</Demo>
+
+```jsx
+// How to set an icon
+function Component() {
+  return (
+    <>
+      <Alert icon theme="info">
+        Alert with icon
+      </Alert>
+      <Alert icon theme="warning">
+        Alert with icon
+      </Alert>
+      <Alert icon theme="success">
+        Alert with icon
+      </Alert>
+      <Alert icon theme="error">
+        Alert with icon
+      </Alert>
+      {/* Promote theme has no icon */}
+    </>
+  )
+}
+```
+
+### Bold
+
+You can surround text with \* to make it bold.
+
+<Demo title="Alert with bold text" background={colors.bgGrey}>
+  <Alert theme="info">Alert with *bold* text</Alert>
+</Demo>
+
+```jsx
+// How to set bold text
+function Component() {
+  return (
+    <>
+      <Alert theme="info">Alert with *bold* text</Alert>
+    </>
+  )
+}
+```
+
+### Action
+
+You can pass cta properties to render a button at the end of the alert text.
+
+<Demo title="Alert with cta" background={colors.bgGrey}>
+  <Alert
+    theme="info"
+    cta={{
+      href: 'https://www.google.com',
+      target: '_blank',
+      text: 'Click here.',
+      onClick: () => alert('CTA Clicked')
+    }}
+  >
+    Alert message.
+  </Alert>
+</Demo>
+
+```jsx
+// How to set cta
+function Component() {
+  return (
+    <>
+      <Alert
+        theme="info"
+        cta={{
+          href: 'https://www.google.com',
+          target: '_blank',
+          text: 'Click here.',
+          onClick: () => alert('CTA Clicked')
+        }}
+      >
+        Alert message.
+      </Alert>
+    </>
+  )
+}
+```
+
+### Others
+
+There is some other properties that can be used with Alert component.
+
+<Demo title="Other Alert properties" background={colors.bgGrey}>
+  <Alert
+    theme="info"
+    icon
+    center
+    noBorderRadius
+    onClose={() => alert('Closing Alert')}
+    spacedClose
+  >
+    Alert message.
+  </Alert>
+</Demo>
+
+```jsx
+// How to use other props
+function Component() {
+  return (
+    <>
+      <Alert
+        theme="info"
+        icon
+        // Other props
+        center
+        noBorderRadius
+        onClose={() => alert('Closing Alert')}
+        spacedClose
+      >
+        Alert message.
+      </Alert>
+    </>
+  )
+}
+```

--- a/src/docs/Button.mdx
+++ b/src/docs/Button.mdx
@@ -2,51 +2,83 @@
 title: Button
 section: components
 ---
+
 import Demo from '@/utils/components/Demo'
 import Button from '@/components/Button'
 
 # Button
+
 ---
 
 - [Props](#Props)
 - [Examples](#Examples)
   - [Theme](#Theme)
   - [Size](#Size)
+  - [Block](#Block)
+  - [Icon](#Icon)
+  - [Loading](#Loading)
+  - [Disabled](#Disabled)
+  - [Round](#Round)
+  - [Click](#Click)
+  - [Href](#Href)
 
-This is a Button
+A flexible component button, with six pre-stablished themes.
+The button can behave like any button with onClick event, or like an anchor with href and target.
 
 ## Props
 
-| Name         | Type          | Default value  | Description      |
-|--------------|---------------|----------------|------------------|
-| `theme`      | **string**    | `primary`      | Button's predefined styles. Available options are: `primary`, `secondary`, `tertiary`, `tertiaryWhite`, `ghostPink`, `ghostGrey` and `ghostWhite`. |
-| `size`       | **string**    | `md`           | Button size. Available options are: `sm`, `md` and `lg`. |
-| `block`      | **boolean**   | `false`        | If true, the button will be displayed in a block. |
-| `disabled`   | **boolean**   | `false`        | It disables the button functionality and shows it with a different style. |
-| `icon`       | **string**    | -              | Displays an icon on the left side of the button. |
-| `iconRight`  | **string**    | -              | Displays as icon on the right side of the button. |
-| `loading`    | **boolean**   | `false`        | The loading state disables the button and displays a spinner inside. |
-| `onClick`    | **function**  | -              | Callback function that is called when the button is clicked. |
-| `href`       | **string**    | -              | The link that the button will navigate to. |
-| `target`     | **string**    | -              | The link target. |
-| `rel`        | **string**    | -              | Only used if the `href` attribute is present. |
-| `id`         | **string**    | -              | The id of the button. |
-| `className`  | **string**    | -              | The className of the button. |
-| `style`      | **object**    | -              | The style of the button. |
-
+| Name        | Type          | Default value | Description                                                                                                                                        |
+| ----------- | ------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`  | **ReactNode** | -             | Children component passed to this container.                                                                                                       |
+| `theme`     | **string**    | `primary`     | Button's predefined styles. Available options are: `primary`, `secondary`, `tertiary`, `tertiaryWhite`, `ghostPink`, `ghostGrey` and `ghostWhite`. |
+| `size`      | **string**    | `md`          | Button size. Available options are: `sm`, `md` and `lg`.                                                                                           |
+| `block`     | **boolean**   | `false`       | If true, the button will be displayed in a block.                                                                                                  |
+| `disabled`  | **boolean**   | `false`       | It disables the button functionality and shows it with a different style.                                                                          |
+| `icon`      | **string**    | -             | Displays an icon on the left side of the button.                                                                                                   |
+| `iconRight` | **string**    | -             | Displays as icon on the right side of the button.                                                                                                  |
+| `round`     | **boolean**   | -             | Property to make the button round when it only has an `iconLeft` and no `children`.                                                                |
+| `loading`   | **boolean**   | `false`       | The loading state disables the button and displays a spinner inside.                                                                               |
+| `onClick`   | **function**  | -             | Callback function that is called when the button is clicked.                                                                                       |
+| `href`      | **string**    | -             | The link that the button will navigate to.                                                                                                         |
+| `target`    | **string**    | -             | The link target.                                                                                                                                   |
+| `rel`       | **string**    | -             | Only used if the `href` attribute is present.                                                                                                      |
+| `id`        | **string**    | -             | The id of the button.                                                                                                                              |
+| `testId`    | **string**    | -             | The data-testid of the button.                                                                                                                     |
+| `className` | **string**    | -             | The className of the button.                                                                                                                       |
+| `style`     | **object**    | -             | The style of the button.                                                                                                                           |
 
 ## Examples
+
 ### Theme
+
 You can choose any of the 7 predefined themes:
+
 <Demo title="Button themes" background={colors.grey400}>
-  <Flexbox display="flex" justifyContent="center" alignItems="center" wrap="wrap">
-    <Button style={{margin: spacing.tiny}}>Primary</Button>
-    <Button theme="secondary" style={{margin: spacing.tiny}}>Secondary</Button>
-    <Button theme="tertiary" style={{margin: spacing.tiny}}>Tertiary</Button>
-    <Button theme="tertiaryWhite" style={{margin: spacing.tiny}}>Tertiary White</Button>
-    <Button theme="ghostPink" style={{margin: spacing.tiny}}>Ghost Pink</Button>
-    <Button theme="ghostGrey" style={{margin: spacing.tiny}}>Ghost Grey</Button>
-    <Button theme="ghostWhite" style={{margin: spacing.tiny}}>Ghost White</Button>
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button style={{ margin: spacing.tiny }}>Primary</Button>
+    <Button theme="secondary" style={{ margin: spacing.tiny }}>
+      Secondary
+    </Button>
+    <Button theme="tertiary" style={{ margin: spacing.tiny }}>
+      Tertiary
+    </Button>
+    <Button theme="tertiaryWhite" style={{ margin: spacing.tiny }}>
+      Tertiary White
+    </Button>
+    <Button theme="ghostPink" style={{ margin: spacing.tiny }}>
+      Ghost Pink
+    </Button>
+    <Button theme="ghostGrey" style={{ margin: spacing.tiny }}>
+      Ghost Grey
+    </Button>
+    <Button theme="ghostWhite" style={{ margin: spacing.tiny }}>
+      Ghost White
+    </Button>
   </Flexbox>
 </Demo>
 
@@ -69,12 +101,25 @@ function Component() {
 ```
 
 ### Size
+
 There's 3 available sizes for Buttons:
+
 <Demo title="Button sizes">
-  <Flexbox display="flex" justifyContent="center" alignItems="center" wrap="wrap">
-    <Button size="sm" style={{margin: spacing.tiny}}>Small</Button>
-    <Button size="md" style={{margin: spacing.tiny}}>Medium</Button>
-    <Button size="lg" style={{margin: spacing.tiny}}>Large</Button>
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button size="sm" style={{ margin: spacing.tiny }}>
+      Small
+    </Button>
+    <Button size="md" style={{ margin: spacing.tiny }}>
+      Medium
+    </Button>
+    <Button size="lg" style={{ margin: spacing.tiny }}>
+      Large
+    </Button>
   </Flexbox>
 </Demo>
 
@@ -87,6 +132,219 @@ function Component() {
       <Button>Small</Button>
       <Button size="md">Medium</Button>
       <Button size="lg">Large</Button>
+    </>
+  )
+}
+```
+
+### Block
+
+<Demo title="Button block">
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button size="md" block>
+      Block
+    </Button>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use block
+function Component() {
+  return (
+    <>
+      <Button size="md" block>
+        Block
+      </Button>
+    </>
+  )
+}
+```
+
+### Icon
+
+<Demo title="Button with icon">
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button iconLeft="search" style={{ margin: spacing.tiny }}>
+      Icon at left side
+    </Button>
+    <Button iconRight="book" style={{ margin: spacing.tiny }}>
+      Icon at right side
+    </Button>
+    <Button iconLeft="search" iconRight="book">
+      Icon at both sides
+    </Button>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to set an icon
+function Component() {
+  return (
+    <>
+      <Button iconLeft="search">Icon at left side</Button>
+      <Button iconRight="book">Icon at right side</Button>
+      <Button iconLeft="search" iconRight="book">
+        Icon at both sides
+      </Button>
+    </>
+  )
+}
+```
+
+### Loading
+
+<Demo title="Button loading">
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button size="md" loading>
+      Loading
+    </Button>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use loading
+function Component() {
+  return (
+    <>
+      <Button size="md" loading>
+        Loading
+      </Button>
+    </>
+  )
+}
+```
+
+### Disabled
+
+<Demo title="Button disabled">
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button size="md" disabled>
+      Disabled
+    </Button>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use disabled
+function Component() {
+  return (
+    <>
+      <Button size="md" disabled>
+        Disabled
+      </Button>
+    </>
+  )
+}
+```
+
+### Round
+
+<Demo title="Button round">
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button size="md" round iconLeft="search" round />
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use round
+function Component() {
+  return (
+    <>
+      {/* The button can be round only when it has no child and has an iconLeft, round properties. */}
+      <Button size="md" round iconLeft="search" round />
+    </>
+  )
+}
+```
+
+### Click
+
+<Demo title="Button onClick">
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button size="md" onClick={() => alert('Button clicked!')}>
+      Button
+    </Button>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use onClick
+function Component() {
+  return (
+    <>
+      <Button size="md" onClick={() => alert('Button clicked!')}>
+        Button
+      </Button>
+    </>
+  )
+}
+```
+
+### Href
+
+The button can recive the href, target, and rel properties of an anchor, to render a link with the styling of a button.
+
+<Demo title="Button href">
+  <Flexbox
+    display="flex"
+    justifyContent="center"
+    alignItems="center"
+    wrap="wrap"
+  >
+    <Button
+      size="md"
+      href="https://www.google.com"
+      target="_blank"
+      rel="nofollow"
+    >
+      Button href
+    </Button>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use href, rel and target
+function Component() {
+  return (
+    <>
+      <Button
+        size="md"
+        href="https://www.google.com"
+        target="_blank"
+        rel="nofollow"
+      >
+        Button href
+      </Button>
     </>
   )
 }

--- a/src/docs/Card.mdx
+++ b/src/docs/Card.mdx
@@ -2,18 +2,96 @@
 title: Card
 section: components
 ---
+
 import Demo from '@/utils/components/Demo'
 import Card from '@/components/Card'
+import { spacing } from '@/components/tokens'
 
 # Card
+
 ---
 
-This is a Card
+Container with a card style.
 
-<Demo title="Raisable card" background={colors.bgGrey}>
-  <Card raisable>This is a card</Card>
+- [Props](#Props)
+  - [Elevations](#Elevations)
+  - [Raisable](#Raisable)
+  - [NoPadding](#NoPadding)
+
+## Props
+
+| Name        | Type          | Default value | Description                                                      |
+| ----------- | ------------- | ------------- | ---------------------------------------------------------------- |
+| `children`  | **ReactNode** | -             | Children component passed to this container.                     |
+| `rest`      | **boolean**   | -             | The rest prop cancels the elevation of the card.                 |
+| `raised`    | **boolean**   | -             | The raised prop gives a higher elevation to the card.            |
+| `raisable`  | **boolean**   | -             | The raisable prop gives a higher elevation to the card on hover. |
+| `noPadding` | **boolean**   | -             | The card has a default padding, use this prop to remove it.      |
+| `id`        | **string**    | -             | The card component id.                                           |
+| `className` | **string**    | -             | The card component className.                                    |
+| `style`     | **object**    | -             | Object with direct style properties.                             |
+
+## Examples
+
+### Elevations
+
+You can choose from 3 elevation types
+
+<Demo title="Elevations of card" background={colors.bgGrey}>
+  <div style={{ marginBottom: spacing.small }}>
+    <Card rest>This is a rest card</Card>
+  </div>
+  <div style={{ marginBottom: spacing.small }}>
+    <Card>This is a default card</Card>
+  </div>
+  <div style={{ marginBottom: spacing.small }}>
+    <Card raised>This is a raised card</Card>
+  </div>
 </Demo>
 
 ```jsx
-<Card>This is a card</Card>
+// How to use elevation
+function Component() {
+  return (
+    <>
+      <Card rest>This is a rest card</Card>
+      <Card>This is a default card</Card>
+      <Card raised>This is a raised card</Card>
+    </>
+  )
+}
+```
+
+### Raisable
+
+<Demo title="Raisable card" background={colors.bgGrey}>
+  <Card raisable>This is a raisable card on hover</Card>
+</Demo>
+
+```jsx
+// How to use raisable
+function Component() {
+  return (
+    <>
+      <Card raisable>This is a raisable card on hover</Card>
+    </>
+  )
+}
+```
+
+### NoPadding
+
+<Demo title="No padding card" background={colors.bgGrey}>
+  <Card noPadding>This is a card with no padding</Card>
+</Demo>
+
+```jsx
+// How to use noPadding
+function Component() {
+  return (
+    <>
+      <Card noPadding>This is a card with no padding</Card>
+    </>
+  )
+}
 ```

--- a/src/docs/Colors.mdx
+++ b/src/docs/Colors.mdx
@@ -2,6 +2,718 @@
 title: Colors
 section: tokens
 ---
+
+import { colors, spacing, shadows } from '@/components/tokens'
+import Demo from '@/utils/components/Demo'
+import Text from '@/components/Text'
+
 # Colors
+
 ---
-Colors docs.
+
+#### Atomic colors following the styleguide.
+
+```jsx
+// How to use colors
+import { colors } from '@occmundial/atomic/tokens'
+
+// Destructuring the colors object
+const { sec } = colors
+
+function Component() {
+  return (
+    <>
+      <div style={{ background: colors.prim }} />
+      <div style={{ background: sec }} />
+    </>
+  )
+}
+```
+
+## Examples
+
+### Colors
+
+<Demo title="Colors" background={colors.white}>
+  {/* Primary */}
+  <div
+    style={{
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.primLighter,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>Lighter</Text>
+        <Text strong>colors.primLighter</Text>
+        <Text>#e4edff</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.primLight,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>Light</Text>
+        <Text strong>colors.primLight</Text>
+        <Text>#c8d9ff</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.prim,
+        paddingTop: spacing.medium,
+        paddingBottom: spacing.medium,
+        paddingRight: spacing.tiny,
+        paddingLeft: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Primary</Text>
+        <Text white strong>
+          colors.prim
+        </Text>
+        <Text white>#083cae</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.primDark,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Dark</Text>
+        <Text white strong>
+          colors.primDark
+        </Text>
+        <Text white>#002b99</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.primDarker,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Darker</Text>
+        <Text white strong>
+          colors.primDarker
+        </Text>
+        <Text white>#001d7c</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Secondary */}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.secLighter,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>Lighter</Text>
+        <Text strong>colors.secLighter</Text>
+        <Text>#feeff3</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.secLight,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>Light</Text>
+        <Text strong>colors.secLight</Text>
+        <Text>#fa90ac</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.sec,
+        paddingTop: spacing.medium,
+        paddingBottom: spacing.medium,
+        paddingRight: spacing.tiny,
+        paddingLeft: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Secondary</Text>
+        <Text white strong>
+          colors.sec
+        </Text>
+        <Text white>#f13465</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.secDark,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Dark</Text>
+        <Text white strong>
+          colors.secDark
+        </Text>
+        <Text white>#cc1b4a</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.secDarker,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Darker</Text>
+        <Text white strong>
+          colors.secDarker
+        </Text>
+        <Text white>#990932</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Ink */}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.inkLightest,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>Lightest</Text>
+        <Text strong>colors.inkLightest</Text>
+        <Text>#dddddd</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.inkLighter,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>Lighter</Text>
+        <Text strong>colors.inkLighter</Text>
+        <Text>#aaaaaa</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.inkLight,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Light</Text>
+        <Text strong white>
+          colors.inkLight
+        </Text>
+        <Text white>#777777</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.ink,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Ink</Text>
+        <Text strong white>
+          colors.ink
+        </Text>
+        <Text white>#222222</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* White */}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.white,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>White</Text>
+        <Text strong>colors.white</Text>
+        <Text>#ffffff</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.bgGrey,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>Grey</Text>
+        <Text strong>colors.bgGrey</Text>
+        <Text>#f5f5f8</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Grey */}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.grey50,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>50</Text>
+        <Text strong>colors.grey50</Text>
+        <Text>#fafafa</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey100,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>100</Text>
+        <Text strong>colors.grey100</Text>
+        <Text>#f5f5f5</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey200,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>200</Text>
+        <Text strong>colors.grey200</Text>
+        <Text>#dddddd</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey300,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>300</Text>
+        <Text strong>colors.grey300</Text>
+        <Text>#cccccc</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey400,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>400</Text>
+        <Text strong>colors.grey400</Text>
+        <Text>#aaaaaa</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey500,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>500</Text>
+        <Text strong white>
+          colors.grey500
+        </Text>
+        <Text white>#999999</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey600,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>600</Text>
+        <Text strong white>
+          colors.grey600
+        </Text>
+        <Text white>#777777</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey700,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>700</Text>
+        <Text strong white>
+          colors.grey700
+        </Text>
+        <Text white>#666666</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey800,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>800</Text>
+        <Text strong white>
+          colors.grey800
+        </Text>
+        <Text white>#444444</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.grey900,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>900</Text>
+        <Text strong white>
+          colors.grey900
+        </Text>
+        <Text white>#222222</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Link */}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.textLink,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Text Link</Text>
+        <Text strong white>
+          colors.textLink
+        </Text>
+        <Text white>#0946CB</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Info*/}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.info,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Info</Text>
+        <Text strong white>
+          colors.info
+        </Text>
+        <Text white>#5736ab</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.infoLight,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text info>Info Light</Text>
+        <Text strong info>
+          colors.infoLight
+        </Text>
+        <Text info>#efebf7</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.white,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text info>Info Text</Text>
+        <Text strong info>
+          colors.infoText
+        </Text>
+        <Text info>#5736ab</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Warning*/}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.warning,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>Warnign</Text>
+        <Text strong>colors.warning</Text>
+        <Text>#ffc549</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.warningLight,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text warning>Warning Light</Text>
+        <Text strong warning>
+          colors.warningLight
+        </Text>
+        <Text warning>#fffaed</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.white,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text warning>Warnign Text</Text>
+        <Text strong warning>
+          colors.warningText
+        </Text>
+        <Text warning>#e69000</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Success*/}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.success,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Success</Text>
+        <Text strong white>
+          colors.success
+        </Text>
+        <Text white>#009537</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.successLight,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text success>Success Light</Text>
+        <Text strong success>
+          colors.successLight
+        </Text>
+        <Text success>#e6f5eb</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.white,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text success>Success Text</Text>
+        <Text strong success>
+          colors.successText
+        </Text>
+        <Text success>#009537</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Error */}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.error,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Error</Text>
+        <Text strong white>
+          colors.error
+        </Text>
+        <Text white>#db3737</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.errorLight,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text error>Error Light</Text>
+        <Text strong error>
+          colors.errorLight
+        </Text>
+        <Text error>#fcebeb</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.white,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text error>Error Text</Text>
+        <Text strong error>
+          colors.errorText
+        </Text>
+        <Text error>#db3737</Text>
+      </Flexbox>
+    </div>
+  </div>
+  {/* Others */}
+  <div
+    style={{
+      marginTop: spacing.medium,
+      width: spacing.xLarge * 10,
+      boxShadow: shadows.lvl4,
+      borderRadius: 10,
+      overflow: 'hidden',
+      maxWidth: '100%'
+    }}
+  >
+    <div
+      style={{
+        background: colors.brand,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text white>Brand</Text>
+        <Text strong white>
+          colors.brand
+        </Text>
+        <Text white>#0046ff</Text>
+      </Flexbox>
+    </div>
+    <div
+      style={{
+        background: colors.bgWhite,
+        padding: spacing.tiny
+      }}
+    >
+      <Flexbox display="flex" direction="row" justifyContent="between">
+        <Text>BG White</Text>
+        <Text strong>colors.bgWhite</Text>
+        <Text>#ffffff</Text>
+      </Flexbox>
+    </div>
+  </div>
+</Demo>

--- a/src/docs/Icon.mdx
+++ b/src/docs/Icon.mdx
@@ -1,0 +1,120 @@
+---
+title: Icon
+section: components
+---
+
+import Demo from '@/utils/components/Demo'
+import Icon from '@/components/Icon'
+import { colors } from '@/components/tokens'
+
+# Icon
+
+---
+
+Component to display any of the icons on the library.
+
+- [Props](#Props)
+  - [Icon](#Icon)
+  - [Sizes](#Sizes)
+  - [Color](#Color)
+  - [Click](#Click)
+
+## Props
+
+| Name         | Type       | Default value | Description                                                                                   |
+| ------------ | ---------- | ------------- | --------------------------------------------------------------------------------------------- |
+| `iconName`   | **string** | -             | Name of the icon to render. It must match with any of the icons of the library, atomic-icons. |
+| `size`       | **number** | -             | The size of the icon to render. This applies for height and width.                            |
+| `color`      | **string** | -             | Hex value of a color. By default the icon has the color defined on the library.               |
+| `hoverColor` | **string** | -             | Hex value of a color, renders on hover.                                                       |
+| `transition` | **string** | `'0.3s all'`  | Transition for animations. For example: **'1s all'**                                          |
+| `onClick`    | **func**   | -             | Function to call when icon is clicked.                                                        |
+| `alt`        | **string** | -             | Alt property.                                                                                 |
+| `id`         | **string** | -             | Id property of the icon.                                                                      |
+| `testId`     | **string** | -             | data-testid property of the icon.                                                             |
+| `className`  | **string** | -             | The icon className.                                                                           |
+| `style`      | **object** | -             | Object with direct style properties.                                                          |
+
+## Examples
+
+### Icon
+
+Renders an icon
+
+<Demo title="Icon" background={colors.bgWhite}>
+  <Icon iconName="search" />
+</Demo>
+
+```jsx
+// How to set an icon
+function Component() {
+  return (
+    <>
+      <Icon iconName='search' />
+    </Icon>
+  )
+}
+
+```
+
+### Sizes
+
+Icon with a custom size
+
+<Demo title="Icon size" background={colors.bgWhite}>
+  <Icon iconName="search" size={64} />
+</Demo>
+
+```jsx
+// How use size
+function Component() {
+  return (
+    <>
+      <Icon iconName='search' size={64} />
+    </Icon>
+  )
+}
+```
+
+### Color
+
+Icon color.
+Color for hover can be adjusted as well.
+
+<Demo title="Icon color" background={colors.bgWhite}>
+  <Icon iconName="search" color={colors.prim} hoverColor={colors.sec} />
+</Demo>
+
+```jsx
+// How to use color and hoverColor
+function Component() {
+  return (
+    <>
+      <Icon iconName='search' color={colors.prim} hoverColor={colors.sec} />
+    </Icon>
+  )
+}
+```
+
+### Click
+
+Its possible to pass an onClick function to the icons.
+
+<Demo title="Icon onClick" background={colors.bgWhite}>
+  <Icon
+    iconName="search"
+    color={colors.sec}
+    onClick={() => alert('Icon clicked!')}
+  />
+</Demo>
+
+```jsx
+// How to use onClick
+function Component() {
+  return (
+    <>
+      <Icon iconName='search' color={colors.sec} onClick={() => alert('Icon clicked!')} />
+    </Icon>
+  )
+}
+```

--- a/src/docs/Tag.mdx
+++ b/src/docs/Tag.mdx
@@ -1,0 +1,159 @@
+---
+title: Tag
+section: components
+---
+
+import Demo from '@/utils/components/Demo'
+import Tag from '@/components/Tag'
+
+# Tag
+
+---
+
+Tag component with different themes.
+
+- [Props](#Props)
+  - [Sizes](#Sizes)
+  - [Themes](#Themes)
+  - [Icon](#Icon)
+
+## Props
+
+| Name        | Type          | Default value | Description                                                   |
+| ----------- | ------------- | ------------- | ------------------------------------------------------------- |
+| `children`  | **ReactNode** | -             | Children component passed to this container.                  |
+| `theme`     | **string**    | `'default'`   | The theme of the Tag component.                               |
+| `iconName`  | **string**    | -             | Name of the icon to render inside the Tag.                    |
+| `size`      | **string**    | `'small'`     | The size of the Tag. Chose from `small`, `medium` and `large` |
+| `className` | **string**    | -             | className of the Tag component.                               |
+| `style`     | **object**    | -             | Object with direct style properties.                          |
+
+## Examples
+
+### Sizes
+
+<Demo title="Tag Sizes" background={colors.bgGrey}>
+  <Flexbox
+    display="flex"
+    direction="row"
+    justifyContent="between"
+    wrap="wrap"
+    alignItems="center"
+  >
+    <Tag theme="primary" size="small">
+      Tag small
+    </Tag>
+    <Tag theme="primary" size="medium">
+      Tag Medium
+    </Tag>
+    <Tag theme="primary" size="large">
+      Tag Large
+    </Tag>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use tag sizes
+function Component() {
+  return (
+    <>
+      <Tag theme="primary" size="small">
+        Tag small
+      </Tag>
+      <Tag theme="primary" size="medium">
+        Tag Medium
+      </Tag>
+      <Tag theme="primary" size="large">
+        Tag Large
+      </Tag>
+    </>
+  )
+}
+```
+
+### Themes
+
+<Demo title="Tag themes" background={colors.bgGrey}>
+  <Flexbox display="flex" direction="row" justifyContent="between" wrap="wrap">
+    <Tag size="medium" theme="default">
+      Tag Default
+    </Tag>
+    <Tag size="medium" theme="primary">
+      Tag Primary
+    </Tag>
+    <Tag size="medium" theme="info">
+      Tag Info
+    </Tag>
+    <Tag size="medium" theme="success">
+      Tag Success
+    </Tag>
+    <Tag size="medium" theme="warning">
+      Tag Warning
+    </Tag>
+    <Tag size="medium" theme="error">
+      Tag Error
+    </Tag>
+    <Tag size="medium" theme="basic">
+      Tag Basic
+    </Tag>
+    <Tag size="medium" theme="link">
+      Tag Link
+    </Tag>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use themes
+function Component() {
+  return (
+    <>
+      <Tag size="medium" theme="default">
+        Tag Default
+      </Tag>
+      <Tag size="medium" theme="primary">
+        Tag Primary
+      </Tag>
+      <Tag size="medium" theme="info">
+        Tag Info
+      </Tag>
+      <Tag size="medium" theme="success">
+        Tag Success
+      </Tag>
+      <Tag size="medium" theme="warning">
+        Tag Warning
+      </Tag>
+      <Tag size="medium" theme="error">
+        Tag Error
+      </Tag>
+      <Tag size="medium" theme="basic">
+        Tag Basic
+      </Tag>
+      <Tag size="medium" theme="link">
+        Tag Link
+      </Tag>
+    </>
+  )
+}
+```
+
+### Icon
+
+<Demo title="Tag Icon" background={colors.bgGrey}>
+  <Tag theme="primary" size="medium" iconName="search">
+    Tag Icon
+  </Tag>
+</Demo>
+
+```jsx
+// How to set an icon
+function Component() {
+  return (
+    <>
+      // The icon should match name with one in atomic-icons library
+      <Tag theme="primary" size="medium" iconName="search">
+        Tag Icon
+      </Tag>
+    </>
+  )
+}
+```

--- a/src/docs/Text.mdx
+++ b/src/docs/Text.mdx
@@ -1,0 +1,247 @@
+---
+title: Text
+section: components
+---
+
+import Demo from '@/utils/components/Demo'
+import Text from '@/components/Text'
+
+# Text
+
+---
+
+- [Props](#Props)
+- [Examples](#Examples)
+  - [Sizes](#Sizes)
+  - [Colors](#Colors)
+  - [Align](#Align)
+  - [Spacing](#Spacing)
+  - [Strong](#Strong)
+
+## Props
+
+| Name           | Type       | Default value | Description                                                           |
+| -------------- | ---------- | ------------- | --------------------------------------------------------------------- |
+| `hero`         | **bool**   | -             | Hero size style.                                                      |
+| `headline`     | **bool**   | -             | Headline size style.                                                  |
+| `heading`      | **bool**   | -             | Heading size style.                                                   |
+| `subheading`   | **bool**   | -             | Subheading size style.                                                |
+| `extraLarge`   | **bool**   | -             | Extra-Large size style.                                               |
+| `large`        | **bool**   | -             | Large size style.                                                     |
+| `standard`     | **bool**   | -             | Standard size style.                                                  |
+| `small`        | **bool**   | -             | Small size style.                                                     |
+| `micro`        | **bool**   | -             | Micro size style.                                                     |
+| `strong`       | **bool**   | -             | Strong style. Only applies in large, standard, small and micro sizes. |
+| `mid`          | **bool**   | -             | Medium emphasis color style.                                          |
+| `primary`      | **bool**   | -             | Primary emphasis color style.                                         |
+| `secondary`    | **bool**   | -             | Secondary emphasis color style.                                       |
+| `success`      | **bool**   | -             | Success emphasis color style.                                         |
+| `error`        | **bool**   | -             | Error emphasis color style.                                           |
+| `warning`      | **bool**   | -             | Warning emphasis color style.                                         |
+| `info`         | **bool**   | -             | Info emphasis color style.                                            |
+| `disabled`     | **bool**   | -             | Disabled emphasis color style.                                        |
+| `white`        | **bool**   | -             | White emphasis color style.                                           |
+| `link`         | **bool**   | -             | Link emphasis color style.                                            |
+| `left`         | **bool**   | -             | Left align style.                                                     |
+| `center`       | **bool**   | -             | Center align style.                                                   |
+| `right`        | **bool**   | -             | Right align style.                                                    |
+| `topXTiny`     | **bool**   | -             | X-Tiny top spacing style.                                             |
+| `topTiny`      | **bool**   | -             | Tiny top spacing style.                                               |
+| `topSmall`     | **bool**   | -             | Small top spacing style.                                              |
+| `topBase`      | **bool**   | -             | Base top spacing style.                                               |
+| `topMedium`    | **bool**   | -             | Medium top spacing style.                                             |
+| `topLarge`     | **bool**   | -             | Large top spacing style.                                              |
+| `topXLarge`    | **bool**   | -             | X-Large top spacing style.                                            |
+| `bottomXTiny`  | **bool**   | -             | X-Tiny bottom spacing style.                                          |
+| `bottomTiny`   | **bool**   | -             | Tiny bottom spacing style.                                            |
+| `bottomSmall`  | **bool**   | -             | Small bottom spacing style.                                           |
+| `bottomBase`   | **bool**   | -             | Base bottom spacing style.                                            |
+| `bottomMedium` | **bool**   | -             | Medium bottom spacing style.                                          |
+| `bottomLarge`  | **bool**   | -             | Large bottom spacing style.                                           |
+| `bottomXLarge` | **bool**   | -             | X-Large bottom spacing style.                                         |
+| `tag`          | **string** | `'p'`         | HTML tag.                                                             |
+| `className`    | **string** | -             | The className of the text.                                            |
+| `id`           | **string** | -             | The id of the text.                                                   |
+
+## Examples
+
+### Sizes
+
+You can choose any of the 9 sizes:
+
+<Demo title="Text sizes" background={colors.white}>
+  <Flexbox display="flex" justifyContent="start" direction="col" wrap="wrap">
+    <Text hero>Hero text</Text>
+    <Text headline>Headline text</Text>
+    <Text heading>Heading text</Text>
+    <Text subheading>Subheading text</Text>
+    <Text extraLarge>Extra-large</Text>
+    <Text large>Large body</Text>
+    <Text standard>Standard body</Text>
+    <Text small>Small Caption</Text>
+    <Text micro>Micro</Text>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use Text sizes
+function Component() {
+  return (
+    <>
+      {/* `standard` is the default value. */}
+      <Text hero>Hero text</Text>
+      <Text headline>Headline text</Text>
+      <Text heading>Heading text</Text>
+      <Text subheading>Subheading text</Text>
+      <Text extraLarge>Extra-large</Text>
+      <Text large>Large body</Text>
+      <Text standard>Standard body</Text>
+      <Text small>Small Caption</Text>
+      <Text micro>Micro</Text>
+    </>
+  )
+}
+```
+
+### Colors
+
+You can choose from 11 colors
+
+<Demo title="Text colors" background={colors.white}>
+  <Flexbox display="flex" justifyContent="start" direction="col" wrap="wrap">
+    <Text>High emphasis</Text>
+    <Text mid>Medium emphasis</Text>
+    <Text low>Low emphasis</Text>
+    <Text primary>Primary</Text>
+    <Text secondary>Secondary</Text>
+    <Text success>Success</Text>
+    <Text error>Error</Text>
+    <Text warning>Warning</Text>
+    <Text info>Info</Text>
+    <Text disabled>Disabled</Text>
+    <Text link>Link</Text>
+    <div style={{ background: colors.prim }}>
+      <Text white>White</Text>
+    </div>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use colors
+function Component() {
+  return (
+    <>
+      <Text>High emphasis</Text>
+      <Text mid>Medium emphasis</Text>
+      <Text low>Low emphasis</Text>
+      <Text primary>Primary</Text>
+      <Text secondary>Secondary</Text>
+      <Text success>Success</Text>
+      <Text error>Error</Text>
+      <Text warning>Warning</Text>
+      <Text info>Info</Text>
+      <Text disabled>Disabled</Text>
+      <Text link>Link</Text>
+      <div style={{ background: colors.prim }}>
+        <Text white>White</Text>
+      </div>
+    </>
+  )
+}
+```
+
+### Align
+
+<Demo title="Text align" background={colors.white}>
+  <Flexbox display="flex" justifyContent="start" direction="col" wrap="wrap">
+    <Text left>Left</Text>
+    <Text center>Center</Text>
+    <Text right>Right</Text>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use alignment
+function Component() {
+  return (
+    <>
+      <Text left>Left</Text>
+      <Text center>Center</Text>
+      <Text right>Right</Text>
+    </>
+  )
+}
+```
+
+### Spacing
+
+You can choose spacing for top and bottom
+
+<Demo title="Text spacing" background={colors.white}>
+  <Flexbox display="flex" justifyContent="start" direction="col" wrap="wrap">
+    <Text bottomXTiny>X-Tiny</Text>
+    <Text bottomTiny>Tiny</Text>
+    <Text bottomSmall>Small</Text>
+    <Text bottomBase>Base</Text>
+    <Text bottomMedium>Medium</Text>
+    <Text bottomLarge>Large</Text>
+    <Text bottomXLarge>XLarge</Text>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use spacing
+function Component() {
+  return (
+    <>
+      {/* These can be applied for top values, such as topXTiny */}
+      <Text bottomXTiny>X-Tiny</Text>
+      <Text bottomTiny>Tiny</Text>
+      <Text bottomSmall>Small</Text>
+      <Text bottomBase>Base</Text>
+      <Text bottomMedium>Medium</Text>
+      <Text bottomLarge>Large</Text>
+      <Text bottomXLarge>XLarge</Text>
+    </>
+  )
+}
+```
+
+### Strong
+
+You can set strong to render a message in bold text
+
+<Demo title="Text strong" background={colors.white}>
+  <Flexbox display="flex" justifyContent="start" direction="col" wrap="wrap">
+    <Text large strong>
+      Large strong
+    </Text>
+    <Text strong>Standard strong</Text>
+    <Text small strong>
+      Small strong
+    </Text>
+    <Text micro strong>
+      Micro strong
+    </Text>
+  </Flexbox>
+</Demo>
+
+```jsx
+// How to use strong
+function Component() {
+  return (
+    <>
+      <Text large strong>
+        Large strong
+      </Text>
+      <Text strong>Standard strong</Text>
+      <Text small strong>
+        Small strong
+      </Text>
+      <Text micro strong>
+        Micro strong
+      </Text>
+    </>
+  )
+}
+```


### PR DESCRIPTION
Added the docs for the following components:

- Button
- Card
- Colors
- Alert
- Icon
- Tag
- Text

https://dev.azure.com/occmundial/Proyectos/_boards/board/t/FCT-CANDIS-UI/Stories/?workitem=11691

Some images of the docs pages, only including some samples since the page are quite large and there are many of them.
![image](https://user-images.githubusercontent.com/56703361/235209676-38f92616-ad6f-4022-885e-fcf3e8be1e01.png)
![image](https://user-images.githubusercontent.com/56703361/235209741-4ab0f982-fc34-4938-9a51-bc0ee0f2c913.png)
![image](https://user-images.githubusercontent.com/56703361/235209792-e8f346c4-5021-4d30-998d-d0cbd9f8dbdf.png)
![image](https://user-images.githubusercontent.com/56703361/235209835-ad531761-bcfd-4abf-b1a7-d5160e6ea6c2.png)
