### PR TITLE
feat: Add type prop to button

### DIFF
--- a/lib/components/Button/index.tsx
+++ b/lib/components/Button/index.tsx
@@ -25,6 +25,7 @@ export interface ButtonProps {
   loading?: boolean
   round?: boolean
   onClick?: EventHandler<SyntheticEvent>
+  type?: 'button' | 'submit' | 'reset' | null
   href?: string
   target?: string
   rel?: string
@@ -45,6 +46,7 @@ const Button = (props: ButtonProps) => {
     loading,
     round,
     onClick,
+    type,
     href,
     target,
     rel,
@@ -119,6 +121,7 @@ const Button = (props: ButtonProps) => {
         id={id}
         style={style}
         data-testid={testId}
+        type={type}
       >
         {content}
         {loadingLayer}

--- a/src/docs/Button.mdx
+++ b/src/docs/Button.mdx
@@ -39,6 +39,7 @@ The button can behave like any button with onClick event, or like an anchor with
 | `round`     | **boolean**   | -             | Property to make the button round when it only has an `iconLeft` and no `children`.                                                                |
 | `loading`   | **boolean**   | `false`       | The loading state disables the button and displays a spinner inside.                                                                               |
 | `onClick`   | **function**  | -             | Callback function that is called when the button is clicked.                                                                                       |
+| `type`      | **string**    | -             | Button's type to use in HTML Forms. Available options are: `button`, `sbumit`, `reset`.                                                            |
 | `href`      | **string**    | -             | The link that the button will navigate to.                                                                                                         |
 | `target`    | **string**    | -             | The link target.                                                                                                                                   |
 | `rel`       | **string**    | -             | Only used if the `href` attribute is present.                                                                                                      |


### PR DESCRIPTION
- Add type prop to button
- Update docs

https://dev.azure.com/occmundial/Proyectos/_boards/board/t/EPH_KRATOS/Stories/?workitem=12046

HTML `button` types
https://www.w3schools.com/tags/att_button_type.asp

Atomic buttons can be set as a `button`, `submit` or `reset` types
![image](https://github.com/occmundial/atomic/assets/56703361/db5e48f0-4aec-4abb-8221-df2d1a5639c1)
