### PR TITLE
feat: Change button themes and styles

### DIFF
--- a/lib/components/Button/Loading/index.tsx
+++ b/lib/components/Button/Loading/index.tsx
@@ -1,0 +1,72 @@
+import { SVGProps } from 'react'
+
+import newColors from '@/tokens/future/colors.json'
+import newSpacing from '@/tokens/future/spacing.json'
+
+export default function Loading(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill={props.fill || newColors['blue-corp'][1000]}
+      width={props.width || newSpacing['size-5']}
+      height={props.height || newSpacing['size-5']}
+      viewBox={`0 0 ${newSpacing['size-5']} ${newSpacing['size-5']}`}
+      {...props}
+    >
+      <circle cx="4" cy="13" r="3">
+        <animate
+          attributeName="r"
+          begin="0s"
+          dur="0.7s"
+          values="2;3;2"
+          calcMode="linear"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="cy"
+          begin="0s"
+          dur="0.7s"
+          values="10;14;10"
+          calcMode="linear"
+          repeatCount="indefinite"
+        />
+      </circle>
+      <circle cx="12" cy="13" r="3">
+        <animate
+          attributeName="r"
+          begin="0.1s"
+          dur="0.7s"
+          values="2;3;2"
+          calcMode="linear"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="cy"
+          begin="0.1s"
+          dur="0.7s"
+          values="10;14;10"
+          calcMode="linear"
+          repeatCount="indefinite"
+        />
+      </circle>
+      <circle cx="20" cy="13" r="3">
+        <animate
+          attributeName="r"
+          begin="0.2s"
+          dur="0.7s"
+          values="2;3;2"
+          calcMode="linear"
+          repeatCount="indefinite"
+        />
+        <animate
+          attributeName="cy"
+          begin="0.2s"
+          dur="0.7s"
+          values="10;14;10"
+          calcMode="linear"
+          repeatCount="indefinite"
+        />
+      </circle>
+    </svg>
+  )
+}

--- a/lib/components/Button/index.tsx
+++ b/lib/components/Button/index.tsx
@@ -5,6 +5,7 @@ import Icon from '@/components/Icon'
 import iconSizes from '@/tokens/iconSizes'
 
 import useStyles from './styles'
+import Loading from './Loading'
 
 export type ButtonTheme =
   | 'primary'
@@ -42,8 +43,8 @@ export interface ButtonProps {
 const Button = (props: ButtonProps) => {
   const {
     children,
-    theme,
-    size,
+    theme = 'primary',
+    size = 'sm',
     block,
     disabled,
     iconLeft,
@@ -79,9 +80,9 @@ const Button = (props: ButtonProps) => {
     <span className={classes.cont}>
       {iconLeft ? (
         <Icon
-          size={size === 'sm' ? iconSizes.tiny : iconSizes.small}
+          size={size === 'sm' ? 16 : 24}
           iconName={iconLeft}
-          className={classnames({ [classes.iconLeft]: children })}
+          className={classnames(classes.icon, { [classes.iconLeft]: children })}
           transition="none"
         />
       ) : (
@@ -90,9 +91,9 @@ const Button = (props: ButtonProps) => {
       {children}
       {iconRight ? (
         <Icon
-          size={size === 'sm' ? iconSizes.tiny : iconSizes.small}
+          size={size === 'sm' ? 16 : 24}
           iconName={iconRight}
-          className={classes.iconRight}
+          className={classnames(classes.icon, classes.iconRight)}
           transition="none"
         />
       ) : (
@@ -102,7 +103,7 @@ const Button = (props: ButtonProps) => {
   )
   const loadingLayer = loading ? (
     <span className={classes.loadCont}>
-      <i className={classes.loadIcon} />
+      <Loading className={classes.icon} />
     </span>
   ) : null
   if (href) {
@@ -140,11 +141,6 @@ const Button = (props: ButtonProps) => {
       </button>
     )
   }
-}
-
-Button.defaultProps = {
-  theme: 'primary',
-  size: 'sm'
 }
 
 export default Button

--- a/lib/components/Button/index.tsx
+++ b/lib/components/Button/index.tsx
@@ -15,6 +15,7 @@ export type ButtonTheme =
   | 'ghostPink'
   | 'ghostGrey'
   | 'ghostWhite'
+  | 'ghost'
   | null
 
 export interface ButtonProps {
@@ -39,6 +40,7 @@ export interface ButtonProps {
   ariaLabel?: string
   name?: string
   value?: any | null
+  darkMode?: boolean
 }
 const Button = (props: ButtonProps) => {
   const {
@@ -62,12 +64,19 @@ const Button = (props: ButtonProps) => {
     testId,
     ariaLabel,
     name,
-    value
+    value,
+    darkMode
   } = props
   const classes = useStyles(props)
+  const getTheme = (): ButtonTheme => {
+    if (theme === 'tertiary' && darkMode) return 'tertiaryWhite'
+    if (theme === 'ghost' && darkMode) return 'ghostWhite'
+    if (theme === 'ghost') return 'ghostGrey'
+    return theme
+  }
   const buttonClassName = classnames(
     classes.btn,
-    { [classes[theme]]: theme },
+    { [classes[getTheme()]]: theme },
     { [classes.loading]: loading },
     { [classes.disabled]: disabled },
     { [classes[size]]: ['md', 'lg'].includes(size) },

--- a/lib/components/Button/styles.ts
+++ b/lib/components/Button/styles.ts
@@ -7,115 +7,164 @@ import { base } from '@/tokens/icons'
 import spinner from '@/tokens/icons/spinner'
 import { ButtonProps } from './'
 
+import newColors from '@/tokens/future/colors.json'
+import newSpacing from '@/tokens/future/spacing.json'
+import borderRadius from '@/tokens/future/borderRadius.json'
+import newFonts from '@/tokens/future/fonts.json'
+import shadows from '@/tokens/future/shadows.json'
+
 export default createUseStyles({
   btn: {
-    display: 'inline-block',
-    boxSizing: 'border-box',
-    position: 'relative',
-    maxWidth: '100%',
-    height: spacing.medium,
-    marginBottom: 0,
-    padding: [0, spacing.small],
-    borderRadius: spacing.radius,
-    fontFamily: fonts.body,
-    fontWeight: 400,
-    fontSize: 14,
-    lineHeight: 1.5,
-    letterSpacing: 0,
-    textAlign: 'center',
-    textDecoration: 'none',
-    whiteSpace: 'nowrap',
+    display: 'inline-block', //*
+    boxSizing: 'border-box', //*
+    position: 'relative', //*
+    maxWidth: '100%', //*
+    marginBottom: 0, //*
+    padding: [newSpacing['size-3'], newSpacing['size-4']], //*
+    borderRadius: borderRadius['br-xs'], //*
+    border: 0,
+    font: newFonts['button-small'], //*
+    textAlign: 'center', //*
+    textDecoration: 'none', //*
+    whiteSpace: 'nowrap', //*
     transition: '0.3s all',
-    cursor: 'pointer',
-    userSelect: 'none',
-    touchAction: 'manipulation',
+    cursor: 'pointer', //*
+    userSelect: 'none', //*
+    touchAction: 'manipulation', //*
     '&:focus': {
-      outline: 'none'
+      outline: 'none' //*
     },
     '&:hover': {
-      textDecoration: 'none'
+      textDecoration: 'none' //*
     }
   },
   cont: {
-    display: 'flex',
-    width: '100%',
-    height: '100%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    pointerEvents: 'none'
+    display: 'flex', //*
+    width: '100%', //*
+    height: '100%', //*
+    alignItems: 'center', //*
+    justifyContent: 'center', //*
+    pointerEvents: 'none' //*
   },
   loadCont: {
-    display: 'flex',
-    width: '100%',
-    height: '100%',
-    alignItems: 'center',
-    justifyContent: 'center',
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    pointerEvents: 'none'
+    display: 'flex', //*
+    width: '100%', //*
+    height: '100%', //*
+    alignItems: 'center', //*
+    justifyContent: 'center', //*
+    position: 'absolute', //*
+    top: 0, //*
+    left: 0, //*
+    pointerEvents: 'none' //*
   },
   // Themes
   primary: {
-    background: colors.sec,
-    color: colors.white,
-    border: `1px solid ${colors.sec}`,
-    '&:hover, &:active': {
-      background: colors.secDark,
-      color: colors.white,
-      borderColor: colors.secDark
+    background: newColors.button.primary.bg.default, //*
+    color: newColors.text.white.primary, //*
+    outline: `2px solid ${newColors.button.primary.border.default}`, //*
+    outlineOffset: '-2px', //*
+    '&:hover': {
+      background: newColors.button.primary.bg.hover //*
     },
-    '& $loadIcon': {
-      background: base(spinner.icon(colors.bgWhite))
+    '&:active': {
+      background: newColors.button.primary.bg.active //*
+    },
+    '&:focus': {
+      outline: `2px solid ${newColors.button.primary.border.default}` //*
+    },
+    '&:not(:active):focus-visible': {
+      boxShadow: shadows['focus-pink'] //*
+    },
+    '&$disabled': {
+      background: newColors.button.primary.bg.disabled, //*
+      color: newColors.text.white.secondary, //*
+      cursor: 'not-allowed' //*
+    },
+    '& $icon': {
+      fill: newColors.icon.inverse.default
+    },
+    '&$disabled $icon': {
+      fill: newColors.icon.inverse.disabled
     }
   },
   secondary: {
-    background: colors.primLighter,
-    color: colors.textLink,
-    border: `1px solid ${colors.primLighter}`,
-    '&:hover, &:active': {
-      background: colors.primLight,
-      color: colors.textLink
+    background: newColors.button.secondary.bg.default, //*
+    color: newColors.text.indigo.primary, //*
+    '&:hover': {
+      background: newColors.button.secondary.bg.hover //*
+    },
+    '&:active': {
+      background: newColors.button.secondary.bg.active //*
+    },
+    '&:not(:active):focus-visible': {
+      boxShadow: shadows['focus-indigo'] //*
     },
     '&$disabled': {
-      background: `${colors.primLighter} !important`,
-      color: `${colors.textLink} !important`,
-      border: `1px solid ${colors.primLighter} !important`
+      background: newColors.button.secondary.bg.disabled, //*
+      color: newColors.text.indigo.secondary //*
     },
-    '& $loadIcon': {
-      background: base(spinner.icon(colors.textLink))
+    '& $icon': {
+      fill: newColors.icon.brand.default
+    },
+    '&$disabled $icon': {
+      fill: newColors.icon.brand.disabled
     }
   },
   tertiary: {
-    background: colors.bgWhite,
-    color: colors.ink,
-    border: `1px solid ${colors.grey200}`,
-    '&:hover, &:active': {
-      color: colors.inkLight
+    background: 'transparent', //*
+    color: newColors.text.indigo.primary, //*
+    outline: `2px solid ${newColors.button.tertiary.border.default}`, //*
+    outlineOffset: '-2px', //*
+    '&:hover': {
+      background: newColors.button.tertiary.bg.hover //*
+    },
+    '&:active': {
+      background: newColors.button.tertiary.bg.active //*
+    },
+    '&:focus': {
+      outline: `2px solid ${newColors.button.tertiary.border.default}` //*
+    },
+    '&:not(:active):focus-visible': {
+      boxShadow: shadows['focus-indigo'] //*
     },
     '&$disabled': {
-      background: `${colors.bgWhite} !important`,
-      color: `${colors.ink} !important`,
-      border: `1px solid ${colors.grey200} !important`
+      background: 'transparent', //*
+      color: newColors.text.indigo.secondary, //*
+      outline: `2px solid ${newColors.button.tertiary.border.disabled}` //*
     },
-    '& $loadIcon': {
-      background: base(spinner.icon(colors.grey600))
+    '& $icon': {
+      fill: newColors.icon.brand.default
+    },
+    '&$disabled $icon': {
+      fill: newColors.icon.brand.disabled
     }
   },
   tertiaryWhite: {
     background: 'transparent',
-    color: colors.white,
-    border: `1px solid ${colors.grey200}`,
-    '&:hover, &:active': {
-      opacity: 0.6
+    color: newColors.text.white.primary,
+    outline: `2px solid ${newColors.button.tertiary.border.inverse.default}`,
+    outlineOffset: '-2px',
+    '&:hover': {
+      background: newColors.button.tertiary.bg.inverse.hover
+    },
+    '&:active': {
+      background: newColors.button.tertiary.bg.inverse.active
+    },
+    '&:focus': {
+      outline: `2px solid ${newColors.button.tertiary.border.inverse.default}`
+    },
+    '&:not(:active):focus-visible': {
+      boxShadow: shadows['focus-white']
     },
     '&$disabled': {
-      background: `transparent !important`,
-      color: `${colors.white} !important`,
-      border: `1px solid ${colors.grey200} !important`
+      background: 'transparent',
+      color: newColors.text.white.secondary
     },
-    '& $loadIcon': {
-      background: base(spinner.icon(colors.bgWhite))
+    '& $icon': {
+      fill: newColors.icon.inverse.default
+    },
+    '&$disabled $icon': {
+      fill: newColors.icon.inverse.disabled
     }
   },
   ghostPink: {
@@ -132,44 +181,54 @@ export default createUseStyles({
       color: `${colors.sec} !important`,
       border: `none !important`
     },
-    '& $loadIcon': {
-      background: base(spinner.icon(colors.sec))
+    '& $icon': {
+      fill: colors.sec
     }
   },
   ghostGrey: {
     background: 'transparent',
-    color: colors.ink,
-    border: 'none',
-    paddingLeft: 0,
-    paddingRight: 0,
-    '&:hover, &:active': {
-      color: colors.inkLight
+    color: newColors.text.corp.secondary,
+    '&:hover': {
+      background: newColors.button.ghost.bg.hover
+    },
+    '&:active': {
+      background: newColors.button.ghost.bg.active
+    },
+    '&:not(:active):focus-visible': {
+      boxShadow: shadows['focus-corp']
     },
     '&$disabled': {
-      background: `transparent !important`,
-      color: `${colors.ink} !important`,
-      border: `none !important`
+      background: 'transparent',
+      color: newColors.text.corp.disabled
     },
-    '& $loadIcon': {
-      background: base(spinner.icon(colors.grey600))
+    '& $icon': {
+      fill: newColors.icon.default.default
+    },
+    '&$disabled $icon': {
+      fill: newColors.icon.default.disabled
     }
   },
   ghostWhite: {
     background: 'transparent',
-    color: colors.white,
-    border: 'none',
-    paddingLeft: 0,
-    paddingRight: 0,
-    '&:hover, &:active': {
-      opacity: 0.6
+    color: newColors.text.white.primary,
+    '&:hover': {
+      background: newColors.button.ghost.bg.inverse.hover
+    },
+    '&:active': {
+      background: newColors.button.ghost.bg.inverse.active
+    },
+    '&:not(:active):focus-visible': {
+      boxShadow: shadows['focus-white']
     },
     '&$disabled': {
-      background: `transparent !important`,
-      color: `${colors.white} !important`,
-      border: `none !important`
+      background: 'transparent',
+      color: newColors.text.white.secondary
     },
-    '& $loadIcon': {
-      background: base(spinner.icon(colors.bgWhite))
+    '& $icon': {
+      fill: newColors.icon.inverse.default
+    },
+    '&$disabled $icon': {
+      fill: newColors.icon.inverse.disabled
     }
   },
   loading: {
@@ -179,62 +238,41 @@ export default createUseStyles({
     }
   },
   disabled: {
-    background: colors.sec,
-    color: colors.white,
-    border: `1px solid ${colors.sec}`,
     cursor: 'default',
-    pointerEvents: 'none',
-    opacity: 0.4,
-    '&:hover, &:active, &:focus': {
-      background: colors.sec,
-      color: colors.white,
-      border: `1px solid ${colors.sec}`
-    }
+    pointerEvents: 'none'
   },
   // Sizes
   md: {
-    fontSize: 16,
-    height: 40,
-    lineHeight: 1.5,
+    font: newFonts['button-medium'], //*
+    padding: [newSpacing['size-3'], newSpacing['size-5']], //*
     '&$iconOnly': {
-      padding: `0 ${spacing.gutter}px`
+      padding: [newSpacing['size-2'], newSpacing['size-2']]
     }
   },
   lg: {
-    fontSize: 16,
-    height: spacing.large,
-    lineHeight: 1.5,
+    font: newFonts['button-large'], //*
+    padding: [newSpacing['size-4'], newSpacing['size-6']], //*
     '&$iconOnly': {
-      padding: `0 ${spacing.small}px`
+      padding: [newSpacing['size-3'], newSpacing['size-3']]
     }
   },
   // Block
   block: {
-    display: 'block',
-    width: '100%'
+    display: 'block', //*
+    width: '100%' //*
   },
   // Icon
+  icon: {},
   iconLeft: {
-    marginRight: 4
+    marginRight: newSpacing['size-2']
   },
   iconRight: {
-    marginLeft: 4
-  },
-  '@keyframes iconRotate': {
-    from: { transform: 'rotate(0deg)' },
-    to: { transform: 'rotate(360deg)' }
+    marginLeft: newSpacing['size-2']
   },
   iconOnly: {
-    padding: [0, spacing.tiny]
+    padding: [newSpacing['size-2'], newSpacing['size-2']]
   },
   round: {
     borderRadius: '50%'
-  },
-  loadIcon: {
-    width: spacing.base,
-    height: spacing.base,
-    display: 'inline-block',
-    transition: '0.3s all',
-    animation: '$iconRotate 1s infinite linear'
   }
 })

--- a/src/docs/Button.mdx
+++ b/src/docs/Button.mdx
@@ -71,19 +71,19 @@ You can choose any of the 7 predefined themes:
       Tertiary
     </Button>
     <div style={{ background: 'rgba(0,43,153,.9)', padding: 12 }}>
-      <Button theme="tertiaryWhite" style={{ margin: spacing.tiny }}>
-        Tertiary White
+      <Button theme="tertiary" darkMode style={{ margin: spacing.tiny }}>
+        Tertiary
       </Button>
     </div>
     <Button theme="ghostPink" style={{ margin: spacing.tiny }}>
       Ghost Pink
     </Button>
-    <Button theme="ghostGrey" style={{ margin: spacing.tiny }}>
-      Ghost Grey
+    <Button theme="ghost" style={{ margin: spacing.tiny }}>
+      Ghost
     </Button>
     <div style={{ background: 'rgba(0,43,153,.9)', padding: 12 }}>
-      <Button theme="ghostWhite" style={{ margin: spacing.tiny }}>
-        Ghost White
+      <Button theme="ghost" darkMode style={{ margin: spacing.tiny }}>
+        Ghost
       </Button>
     </div>
   </Flexbox>

--- a/src/docs/Button.mdx
+++ b/src/docs/Button.mdx
@@ -56,7 +56,7 @@ The button can behave like any button with onClick event, or like an anchor with
 
 You can choose any of the 7 predefined themes:
 
-<Demo title="Button themes" background={colors.grey400}>
+<Demo title="Button themes">
   <Flexbox
     display="flex"
     justifyContent="center"
@@ -70,18 +70,22 @@ You can choose any of the 7 predefined themes:
     <Button theme="tertiary" style={{ margin: spacing.tiny }}>
       Tertiary
     </Button>
-    <Button theme="tertiaryWhite" style={{ margin: spacing.tiny }}>
-      Tertiary White
-    </Button>
+    <div style={{ background: 'rgba(0,43,153,.9)', padding: 12 }}>
+      <Button theme="tertiaryWhite" style={{ margin: spacing.tiny }}>
+        Tertiary White
+      </Button>
+    </div>
     <Button theme="ghostPink" style={{ margin: spacing.tiny }}>
       Ghost Pink
     </Button>
     <Button theme="ghostGrey" style={{ margin: spacing.tiny }}>
       Ghost Grey
     </Button>
-    <Button theme="ghostWhite" style={{ margin: spacing.tiny }}>
-      Ghost White
-    </Button>
+    <div style={{ background: 'rgba(0,43,153,.9)', padding: 12 }}>
+      <Button theme="ghostWhite" style={{ margin: spacing.tiny }}>
+        Ghost White
+      </Button>
+    </div>
   </Flexbox>
 </Demo>
 
@@ -269,7 +273,7 @@ function Component() {
     alignItems="center"
     wrap="wrap"
   >
-    <Button size="md" round iconLeft="search" round />
+    <Button round iconLeft="search" />
   </Flexbox>
 </Demo>
 
@@ -279,7 +283,7 @@ function Component() {
   return (
     <>
       {/* The button can be round only when it has no child and has an iconLeft, round properties. */}
-      <Button size="md" round iconLeft="search" round />
+      <Button size="md" round iconLeft="search" />
     </>
   )
 }
@@ -326,7 +330,7 @@ The button can recive the href, target, and rel properties of an anchor, to rend
   >
     <Button
       size="md"
-      href="https://www.google.com"
+      href="https://github.com/occmundial/atomic"
       target="_blank"
       rel="nofollow"
     >


### PR DESCRIPTION
BREAKING CHANGE: The themes of the Button component change to match the styles of the button in the new design system. The current themes have slightly different names to the new ones but they all have a corresponding new theme that matches, except for the ghostPink theme.
Add a `ghost` theme and a darkMode prop. The darkMode prop only applies for the `tertiary` and `ghost` themes. Their legacy counterpart would be to use the `tertiaryWhite` (`tertiary` theme in dark mode), `ghostGrey` (`ghost`theme without dark mode) and `ghostWhite` (`ghost` theme in darkMode).

![image](https://github.com/occmundial/atomic/assets/26333425/25349d8c-5d56-44a0-b938-1bade578fbf8)
